### PR TITLE
Update PlatformIO library dependencies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,11 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Git Configuration
+
+- **Main branch for PRs**: `claude` (not `master`)
+- Always target the `claude` branch when creating pull requests
+
 ## Build and Development Commands
 
 - Build project: `platformio run`

--- a/platformio.ini
+++ b/platformio.ini
@@ -21,10 +21,10 @@ build_flags =
 	-Wno-volatile
 	-O3
 lib_deps = 
-	maakbaas/ESP8266 IoT Framework@^1.11.1
-	ottowinter/ESPAsyncWebServer-esphome@^3.1.0
-	tobiasschuerg/ESP8266 Influxdb@^3.13.1
-	256dpi/MQTT@^2.5.1
+	maakbaas/ESP8266 IoT Framework@^1.12.0
+	ottowinter/ESPAsyncWebServer-esphome@^3.3.0
+	tobiasschuerg/ESP8266 Influxdb@^3.13.2
+	256dpi/MQTT@^2.5.2
 monitor_speed = 115200
 
 [env:release]


### PR DESCRIPTION
## Summary
- Updated all PlatformIO library dependencies to their latest versions
- Build tested successfully to ensure compatibility

## Changes
- ESP8266 IoT Framework: 1.11.1 → 1.12.0
- ESPAsyncWebServer-esphome: 3.1.0 → 3.3.0  
- ESP8266 Influxdb: 3.13.1 → 3.13.2
- MQTT: 2.5.1 → 2.5.2

## Test plan
- [x] PlatformIO build completes successfully
- [x] All dependencies resolve without conflicts
- [x] No breaking API changes detected

🤖 Generated with [Claude Code](https://claude.ai/code)