### PR TITLE
Add GitHub Actions workflow for PlatformIO builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,49 @@
+---
+name: PlatformIO Build
+
+"on":
+  push:
+    branches: [claude, master]
+  pull_request:
+    branches: [claude, master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Cache PlatformIO
+        uses: actions/cache@v4
+        with:
+          path: ~/.platformio
+          key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install PlatformIO
+        run: |
+          python -m pip install --upgrade pip
+          pip install --upgrade platformio
+
+      - name: Build PlatformIO project
+        run: pio run
+
+      - name: Upload firmware artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: firmware
+          path: .pio/build/release/firmware.bin
+          retention-days: 30


### PR DESCRIPTION
## Summary
- Add automated CI/CD pipeline using GitHub Actions for PlatformIO builds
- Triggers on push and pull requests to claude and master branches

## Features
- **Automated builds**: Compiles firmware on every push/PR
- **Dependency caching**: Speeds up builds by caching pip and PlatformIO dependencies  
- **Artifact uploads**: Stores compiled firmware.bin with 30-day retention
- **Latest tooling**: Uses current GitHub Actions versions (checkout@v4, cache@v4, setup-python@v5)

## Test plan
- [x] YAML syntax validated with yamllint
- [x] Workflow targets both claude and master branches
- [ ] Verify build succeeds in GitHub Actions environment

🤖 Generated with [Claude Code](https://claude.ai/code)