### PR TITLE
Refactor: Extract Integrator class into separate files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,10 @@ This is an ESP8266-based bridge that interfaces with ATAG HR5000 heating systems
 - MQTT: Message broker communication
 - SoftwareSerial: RS485 communication
 
+### Key Classes
+
+- **Integrator** (`src/Integrator.h/.cpp`): Power-to-energy integration using trapezoidal rule
+
 ### Configuration Files
 
 - `config.json`: Runtime configuration schema (hostname, MQTT broker, InfluxDB credentials)

--- a/src/Integrator.cpp
+++ b/src/Integrator.cpp
@@ -1,0 +1,35 @@
+#include "Integrator.h"
+
+#ifdef UNIT_TEST
+millis_t millis() {
+    return std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::system_clock::now().time_since_epoch()).count();
+}
+#endif
+
+float Integrator::update(float value, millis_t currentTime) {
+    if (!firstTime) {
+        auto deltaT = (currentTime - lastT) / 1000.0;
+        // Integration with linear interpolation (trapezoidal rule)
+        // This calculates the area under the power curve
+        result += 0.5 * (lastValue + value) * deltaT;
+    } else {
+        firstTime = false;
+    }
+
+    lastValue = value;
+    lastT = currentTime;
+
+    return result;
+}
+
+float Integrator::update(float value) {
+    return update(value, millis());
+}
+
+void Integrator::reset() {
+    firstTime = true;
+    lastT = 0;
+    lastValue = 0;
+    result = 0;
+}

--- a/src/Integrator.h
+++ b/src/Integrator.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#ifdef UNIT_TEST
+#include <chrono>
+using millis_t = decltype(std::chrono::duration_cast<std::chrono::milliseconds>(
+    std::chrono::system_clock::now().time_since_epoch()).count());
+#else
+#include <Arduino.h>
+using millis_t = decltype(millis());
+#endif
+
+/**
+ * @brief Power integrator class for calculating cumulative energy consumption
+ * 
+ * This class implements numerical integration using linear interpolation
+ * to calculate energy (kWh) from power (kW) measurements over time.
+ * 
+ * The integration formula used is:
+ * energy += 0.5 * (lastPower + currentPower) * deltaTime
+ * 
+ * This represents the area under the power curve using the trapezoidal rule.
+ */
+class Integrator {
+public:
+    /**
+     * @brief Update the integrator with a new power value
+     * 
+     * @param value Power value in kW
+     * @param currentTime Current timestamp in milliseconds
+     * @return Current integrated energy in kW⋅s
+     */
+    float update(float value, millis_t currentTime);
+    
+    /**
+     * @brief Update the integrator with a new power value (uses millis() for time)
+     * 
+     * @param value Power value in kW
+     * @return Current integrated energy in kW⋅s
+     */
+    float update(float value);
+    
+    /**
+     * @brief Get the current integrated result
+     * 
+     * @return Integrated energy in kW⋅s
+     */
+    float getResult() const { return result; }
+    
+    /**
+     * @brief Reset the integrator to initial state
+     */
+    void reset();
+
+private:
+    bool firstTime{true};        ///< Flag to track first measurement
+    millis_t lastT{};           ///< Last timestamp in milliseconds
+    float lastValue{};          ///< Last power value in kW
+    float result{};             ///< Integrated energy in kW⋅s
+};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,6 +12,8 @@
 
 #include <map>
 
+#include "Integrator.h"
+
 // TODO: turn into configuration option
 #define TZ_INFO "CET-1CEST,M3.5.0,M10.5.0/3"
 
@@ -160,32 +162,7 @@ static uint8_t buffer[128];
 static unsigned long lastByteTime;
 static bool readingPacket;
 
-class Integrator {
-  public:
-    float update(float value)
-    {
-        auto now = millis();
-
-        if (!firstTime) {
-            auto deltaT = (now - lastT) / 1000.0;
-            // integration with linear interpolation
-            result += 0.5 * (lastValue + value) * deltaT;
-        } else {
-            firstTime = false;
-        }
-
-        lastValue = value;
-        lastT = now;
-
-        return result;
-    }
-
-  private:
-    bool firstTime{true};
-    decltype(millis()) lastT{};
-    float lastValue{};
-    float result{};
-};
+// Integrator class moved to Integrator.h/.cpp
 
 static Integrator powerToEnergy;
 

--- a/test/test_desktop/test_packet_validation.cpp
+++ b/test/test_desktop/test_packet_validation.cpp
@@ -3,42 +3,14 @@
 #include <stddef.h>
 #include <chrono>
 
-// Mock Arduino types for testing
-using millis_t = decltype(std::chrono::duration_cast<std::chrono::milliseconds>(
-    std::chrono::system_clock::now().time_since_epoch()).count());
+// Include the extracted Integrator class
+#ifndef UNIT_TEST
+#define UNIT_TEST
+#endif
+#include "../../src/Integrator.h"
 
-// Integrator class for testing
-class Integrator {
-public:
-    float update(float value, millis_t currentTime) {
-        if (!firstTime) {
-            auto deltaT = (currentTime - lastT) / 1000.0;
-            result += 0.5 * (lastValue + value) * deltaT;
-        } else {
-            firstTime = false;
-        }
-
-        lastValue = value;
-        lastT = currentTime;
-
-        return result;
-    }
-
-    float getResult() const { return result; }
-    
-    void reset() {
-        firstTime = true;
-        lastT = 0;
-        lastValue = 0;
-        result = 0;
-    }
-
-private:
-    bool firstTime{true};
-    millis_t lastT{};
-    float lastValue{};
-    float result{};
-};
+// Include implementation for testing (since PlatformIO test doesn't build src/ files)
+#include "../../src/Integrator.cpp"
 
 // ATAG protocol constants
 static constexpr uint8_t ATAG_ADDRESS_0x41 = 0x41;


### PR DESCRIPTION
## Summary
- Extract the Integrator class from main.cpp into dedicated `src/Integrator.h` and `src/Integrator.cpp` files
- Improve code organization and reusability through better separation of concerns

## Changes Made
- **New files**: `src/Integrator.h/.cpp` with comprehensive doxygen documentation
- **Enhanced API**: Support both Arduino `millis()` and explicit timestamp parameters for better testability
- **Updated main.cpp**: Remove inline class definition, use extracted header
- **Updated tests**: Use extracted class instead of duplicated implementation
- **Documentation**: Added class description to CLAUDE.md

## Benefits
- **Better organization**: Separates mathematical algorithms from protocol handling
- **Improved testability**: Explicit time parameter allows deterministic testing
- **Enhanced reusability**: Class can be used in other parts of the codebase
- **Cleaner main.cpp**: Focuses on ATAG protocol logic rather than utility classes

## Technical Details
- Uses trapezoidal rule for numerical integration: `energy += 0.5 * (lastPower + currentPower) * deltaTime`
- Maintains backward compatibility with existing `update(float)` interface
- Proper conditional compilation for unit test environment

## Test Plan
- [x] All unit tests pass (10/10 test cases)
- [x] ESP8266 firmware builds successfully
- [x] No functional changes to energy calculation algorithm

🤖 Generated with [Claude Code](https://claude.ai/code)