### PR TITLE
Make timezone configurable instead of hardcoded

### DIFF
--- a/config.json
+++ b/config.json
@@ -67,5 +67,12 @@
     "label": "MQTT Broker Port",
     "type": "uint16_t",
     "value": 1883
+  },
+  {
+    "name": "timezone",
+    "label": "Timezone",
+    "type": "char",
+    "length": 64,
+    "value": "CET-1CEST,M3.5.0,M10.5.0/3"
   }
 ]

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -14,8 +14,6 @@
 
 #include "Integrator.h"
 
-// TODO: turn into configuration option
-#define TZ_INFO "CET-1CEST,M3.5.0,M10.5.0/3"
 
 #ifndef MQTT_PREFIX
 #define MQTT_PREFIX "atagbridge"
@@ -138,7 +136,7 @@ void setup()
 
     Dumper.begin();
 
-    timeSync(TZ_INFO, "de.pool.ntp.org", "pool.ntp.org");
+    timeSync(configManager.data.timezone, "de.pool.ntp.org", "pool.ntp.org");
 
     mqtt.begin(net);
     mqttConnect();


### PR DESCRIPTION
## Summary
- Add timezone configuration option to config.json with default CET value
- Remove hardcoded TZ_INFO define from main.cpp
- Update timeSync call to use configManager.data.timezone
- Resolves TODO comment about making timezone configurable

## Test plan
- [x] Build completes successfully
- [x] All unit tests pass
- [x] Configuration system properly loads timezone value
- [x] No hardcoded timezone constants remain in code

🤖 Generated with [Claude Code](https://claude.ai/code)